### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A [ModelContextProtocol](https://modelcontextprotocol.io) server that enables AI assistants to interact with Figma files. This server provides tools for viewing, commenting, and analyzing Figma designs directly through the ModelContextProtocol.
 
+<a href="https://glama.ai/mcp/servers/7muhz3xl36">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/7muhz3xl36/badge" alt="Figma Server MCP server" />
+</a>
+
 ## Features
 
 - Add a Figma file to your chat with Claude by providing the url


### PR DESCRIPTION
This PR adds a badge for the [Figma MCP Server](https://glama.ai/mcp/servers/7muhz3xl36) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/7muhz3xl36">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/7muhz3xl36/badge" alt="Figma Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.